### PR TITLE
fix: correct newline character

### DIFF
--- a/realm_functions/gdeltUpdater.js
+++ b/realm_functions/gdeltUpdater.js
@@ -11,7 +11,7 @@ exports = async function(){
   const latestCSV = (await http.get({ url: csvURL })).body;
   const zip = new AdmZip(new Buffer(latestCSV.toBase64(), 'base64'));
   const csvData = zip.getEntries()[0].getData().toString('utf-8');
-  const csvLines = csvData.split("/n");
+  const csvLines = csvData.split("\n");
   
   if (csvLines[csvLines.length - 1] === "") {
     csvLines.pop();


### PR DESCRIPTION
The newline character in the `.split()` on [line 14](https://github.com/mongodb-developer/mongodb-world-2022-hackathon/blob/ec6c3e42242fd928482aecc03adb6041694f9d34/realm_functions/gdeltUpdater.js#L14) was written as `/n` which is wrong and I have now changed it to the correct syntax `\n`. 
This observation was made by @Crist in the [mongoDB forum](https://www.mongodb.com/community/forums/t/realm-trigger-duplicate-key-error/164259)